### PR TITLE
Update Robot Assets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kscale-assets"]
+	path = kscale-assets
+	url = https://github.com/kscalelabs/kscale-assets.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
-recursive-include kos_sim/ *.py *.txt py.typed MANIFEST.in
+include LICENSE
+include README.md
+recursive-include kos_sim/ *.py *.txt py.typed
+recursive-include kscale-assets *

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install -e .
 4. Run the simulator
 
 ```bash
-kos-sim kbot-v1
+kos-sim kbot-v2
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ First, start the `kos-sim` backend:
 kos-sim kbot-v1
 ```
 
+The simulator will automatically check for and update the latest robot assets from the [kscale-assets](https://github.com/kscalelabs/kscale-assets) repository.
+
 Then, in a separate terminal, run the example client:
 
 ```bash
@@ -24,15 +26,51 @@ python -m examples.kbot
 
 You should see the simulated K-Bot move in response to the client commands.
 
+## Development Setup
+
+1. Clone the repository
+```bash
+git clone --recursive https://github.com/kscalelabs/kos-sim.git
+```
+
+Or if you've already cloned the repository, initialize the submodule:
+
+```bash
+git submodule update --init --recursive
+```
+
+2. Make sure you're using Python 3.11 or greater
+
+```bash
+python --version  # Should show Python 3.11 or greater
+```
+
+3. Install dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+4. Run the simulator
+
+```bash
+kos-sim kbot-v1
+```
+
+
 ## Possible Bugs
 
 If you find that your robot is jittering on the ground, try increasing `iterations` and `ls_iterations` in your mjcf options.
+
 ```xml
 <option iterations="6" ls_iterations="6">
 </option>
 ```
 
 Also, to clip actuator ctrl values, be sure to send a `configure_actuator` KOS command with `max_torque` set.
+
 ```python
 await kos.actuator.configure_actuator(
     actuator_id=actuator.actuator_id,

--- a/examples/default_humanoid/save_video.py
+++ b/examples/default_humanoid/save_video.py
@@ -7,6 +7,7 @@ from pykos import KOS
 
 logger = logging.getLogger(__name__)
 
+
 async def main() -> None:
     async with KOS() as kos:
         await kos.sim.reset(

--- a/examples/default_humanoid/sinusoid.py
+++ b/examples/default_humanoid/sinusoid.py
@@ -42,6 +42,7 @@ ACTUATOR_LIST: list[Actuator] = [
     Actuator(actuator_id=21, nn_id=20, kp=50.0, kd=1.0, max_torque=30.0, joint_name="elbow_left"),
 ]
 
+
 async def configure_joints(kos: KOS) -> None:
     for actuator in ACTUATOR_LIST:
         await kos.actuator.configure_actuator(
@@ -50,6 +51,7 @@ async def configure_joints(kos: KOS) -> None:
             kd=actuator.kd,
             max_torque=actuator.max_torque,
         )
+
 
 async def reset_joints(kos: KOS) -> None:
     await kos.sim.reset(
@@ -61,14 +63,15 @@ async def reset_joints(kos: KOS) -> None:
         ],
     )
 
+
 async def command_zero_joints(kos: KOS) -> None:
     await kos.actuator.command_actuators(
         [{"actuator_id": actuator.actuator_id, "position": 0.0, "velocity": 0.0} for actuator in ACTUATOR_LIST]
     )
 
+
 async def main() -> None:
     async with KOS() as kos:
-
         await reset_joints(kos)
         await configure_joints(kos)
 
@@ -98,6 +101,7 @@ async def main() -> None:
             print(f"pos: {cur_pos}")
 
             await asyncio.sleep(0.02)
+
 
 # Start the server with
 # `python -m kos_sim.server default-humanoid`

--- a/examples/kbot/walking.py
+++ b/examples/kbot/walking.py
@@ -119,7 +119,7 @@ async def simple_walking(
             "prev_actions.1": np.zeros(10).astype(np.float32),
             "projected_gravity.1": np.zeros(3).astype(np.float32),
             "buffer.1": np.zeros(570).astype(np.float32),
-    }
+        }
 
         x_vel_cmd = 1.0
         y_vel_cmd = 0.0

--- a/kos_sim/assets.py
+++ b/kos_sim/assets.py
@@ -1,0 +1,97 @@
+"""Asset management for robot models."""
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional, Dict
+
+from kos_sim import logger
+from pydantic import BaseModel, Field
+
+class JointMetadataOutput(BaseModel):
+    id: Optional[int] = Field(None, title="Id")
+    kp: Optional[str] = Field(None, title="Kp")
+    kd: Optional[str] = Field(None, title="Kd")
+    armature: Optional[str] = Field(None, title="Armature")
+    friction: Optional[str] = Field(None, title="Friction")
+    offset: Optional[str] = Field(None, title="Offset")
+    flipped: Optional[bool] = Field(None, title="Flipped")
+
+class RobotURDFMetadataOutput(BaseModel):
+    joint_name_to_metadata: Optional[Dict[str, JointMetadataOutput]] = Field(None, title="Joint Name To Metadata")
+    control_frequency: Optional[str] = Field(None, title="Control Frequency")
+
+def get_assets_dir() -> Path:
+    """Get the directory containing the assets."""
+    if os.environ.get("KOS_SIM_INSTALLED"):
+        return Path(__file__).parent / "kscale-assets"
+    return Path(__file__).parent.parent / "kscale-assets"
+
+
+def get_available_models() -> list[str]:
+    """Get a list of available model names."""
+    assets_dir = get_assets_dir()
+    if not assets_dir.exists():
+        return []
+    models_dir = assets_dir / ""
+    if not models_dir.exists():
+        return []
+    return [d.name for d in models_dir.iterdir() if d.is_dir()]
+
+
+def ensure_assets_up_to_date() -> bool:
+    """Ensure assets are up to date by checking and updating if necessary."""
+    assets_dir = get_assets_dir()
+    if not assets_dir.exists():
+        logger.error("Assets directory not found at %s", assets_dir)
+        return False
+
+    try:
+        # Check if we need to update
+        subprocess.run(["git", "submodule", "status"], check=True, capture_output=True, cwd=Path(__file__).parent.parent)
+        
+        # Update the submodule
+        subprocess.run(["git", "submodule", "update", "--remote", "--merge"], check=True, cwd=Path(__file__).parent.parent)
+        logger.info("Assets are up to date")
+        return True
+    except subprocess.CalledProcessError as e:
+        logger.error("Failed to update assets: %s", e)
+        return False
+    except Exception as e:
+        logger.error("Unexpected error updating assets: %s", e)
+        return False
+
+
+def get_model_path(model_name: str) -> Path:
+    """Get the path to a model's assets."""
+    return get_assets_dir() / model_name
+
+
+def get_model_metadata(model_name: str) -> Optional[str]:
+    """Get the metadata for a model."""
+    model_path = get_model_path(model_name)
+    metadata_path = model_path / "metadata.json"
+    if not metadata_path.exists():
+        logger.error("Metadata not found for model %s", model_name)
+        return None
+    
+    try:
+        import json
+        data = json.loads(metadata_path.read_text())
+        
+        # Convert numeric values to strings to satisfy Pydantic validation
+        def convert_numeric_to_string(obj):
+            if isinstance(obj, dict):
+                return {k: convert_numeric_to_string(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [convert_numeric_to_string(item) for item in obj]
+            elif isinstance(obj, (int, float)):
+                return str(obj)
+            else:
+                return obj
+        
+        # Convert the modified dict back to a JSON string
+        return json.dumps(convert_numeric_to_string(data))
+    except json.JSONDecodeError:
+        logger.error("Failed to parse metadata JSON for model %s", model_name)
+        return None 

--- a/kos_sim/requirements.txt
+++ b/kos_sim/requirements.txt
@@ -10,3 +10,4 @@ pykos
 onnxruntime
 scipy
 mediapy
+pydantic

--- a/kos_sim/requirements.txt
+++ b/kos_sim/requirements.txt
@@ -1,7 +1,6 @@
 # requirements.txt
 
 colorlogging
-kscale
 mujoco
 mujoco-scenes
 mujoco-python-viewer

--- a/kos_sim/server.py
+++ b/kos_sim/server.py
@@ -17,9 +17,10 @@ from kos_protos import actuator_pb2_grpc, imu_pb2_grpc, process_manager_pb2_grpc
 from mujoco_scenes.mjcf import list_scenes
 
 from kos_sim import logger
-from kos_sim.assets import RobotURDFMetadataOutput, ensure_assets_up_to_date, get_model_metadata, get_model_path
+from kos_sim.assets import ensure_assets_up_to_date, get_model_metadata, get_model_path
 from kos_sim.services import ActuatorService, IMUService, ProcessManagerService, SimService
 from kos_sim.simulator import MujocoSimulator
+from kos_sim.utils import RobotURDFMetadataOutput
 from kos_sim.video_recorder import VideoRecorder
 
 

--- a/kos_sim/server.py
+++ b/kos_sim/server.py
@@ -17,10 +17,11 @@ from kos_protos import actuator_pb2_grpc, imu_pb2_grpc, process_manager_pb2_grpc
 from mujoco_scenes.mjcf import list_scenes
 
 from kos_sim import logger
-from kos_sim.assets import ensure_assets_up_to_date, get_model_metadata, get_model_path, RobotURDFMetadataOutput
+from kos_sim.assets import RobotURDFMetadataOutput, ensure_assets_up_to_date, get_model_metadata, get_model_path
 from kos_sim.services import ActuatorService, IMUService, ProcessManagerService, SimService
 from kos_sim.simulator import MujocoSimulator
 from kos_sim.video_recorder import VideoRecorder
+
 
 @dataclass
 class SimulationRandomizationConfig:
@@ -210,7 +211,7 @@ async def serve(
     metadata_json = get_model_metadata(model_name)
     if metadata_json is None:
         raise ValueError(f"No metadata found for model {model_name}")
-    
+
     model_metadata = RobotURDFMetadataOutput.model_validate_json(metadata_json)
 
     model_path = next(

--- a/kos_sim/simulator.py
+++ b/kos_sim/simulator.py
@@ -13,7 +13,7 @@ import numpy as np
 from mujoco_scenes.mjcf import load_mjmodel
 
 from kos_sim import logger
-from kos_sim.assets import RobotURDFMetadataOutput
+from kos_sim.utils import RobotURDFMetadataOutput
 
 T = TypeVar("T")
 

--- a/kos_sim/simulator.py
+++ b/kos_sim/simulator.py
@@ -10,10 +10,10 @@ from typing import Literal, NotRequired, TypedDict, TypeVar
 import mujoco
 import mujoco_viewer
 import numpy as np
-from kscale.web.gen.api import RobotURDFMetadataOutput
 from mujoco_scenes.mjcf import load_mjmodel
 
 from kos_sim import logger
+from kos_sim.assets import RobotURDFMetadataOutput
 
 T = TypeVar("T")
 

--- a/kos_sim/utils.py
+++ b/kos_sim/utils.py
@@ -1,9 +1,0 @@
-"""Defines some utility functions."""
-
-import os
-from pathlib import Path
-
-
-def get_sim_artifacts_path() -> Path:
-    base_path = os.getenv("KOS_SIM_CACHE_PATH", ".kos-sim")
-    return Path(base_path).expanduser().resolve()

--- a/kos_sim/utils.py
+++ b/kos_sim/utils.py
@@ -1,0 +1,24 @@
+"""Utility functions and classes."""
+
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class JointMetadataOutput(BaseModel):
+    """Metadata for a joint in the robot URDF."""
+
+    id: Optional[int] = Field(None, title="Id")
+    kp: Optional[str] = Field(None, title="Kp")
+    kd: Optional[str] = Field(None, title="Kd")
+    armature: Optional[str] = Field(None, title="Armature")
+    friction: Optional[str] = Field(None, title="Friction")
+    offset: Optional[str] = Field(None, title="Offset")
+    flipped: Optional[bool] = Field(None, title="Flipped")
+
+
+class RobotURDFMetadataOutput(BaseModel):
+    """Metadata for the robot URDF."""
+
+    joint_name_to_metadata: Optional[Dict[str, JointMetadataOutput]] = Field(None, title="Joint Name To Metadata")
+    control_frequency: Optional[str] = Field(None, title="Control Frequency")

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ setup(
         "examples": requirements_examples,
     },
     packages=["kos_sim"],
+    package_data={
+        "kos_sim": ["py.typed", "requirements.txt", "kscale-assets/**/*"],
+    },
     entry_points={
         "console_scripts": [
             "kos-sim=kos_sim.server:main",


### PR DESCRIPTION
- Uses https://github.com/kscalelabs/kscale-assets assets
- Ensures assets up to date
- removed k-scale APIs 

Tests:
- ran `kos-sim [robot name]` for every robot. All robots loaded

Todo:
- change all metadata names to metadata in kscale-assets. Linked PR: https://github.com/kscalelabs/kscale-assets/pull/4
